### PR TITLE
Feature - Added partitioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ key             | Type         | Description
 
 key                 | Type      | Description
 ------------------- | --------- | ---
-`topic` (required)  | `string`  | Topic to send messages to
-`attributes`        | `string`  | Compression attribute. Check [kafka-node docs](https://github.com/SOHU-Co/kafka-node/#sendpayloads-cb-1) for possible values
-`partition`         | `string`  | Partition to send message to
-`settings`          | `object`  | Values used to handle producer acks and publish timeouts. Check [kafka node' HighLevelProducer](https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38) for possible values
+`topic` (required)  | `string`      | Topic to send messages to
+`attributes`        | `string`      | Compression attribute. Check [kafka-node docs](https://github.com/SOHU-Co/kafka-node/#sendpayloads-cb-1) for possible values
+`settings`          | `object`      | Values used to handle producer acks and publish timeouts. Check [kafka node' HighLevelProducer](https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38) for possible values
+`partition`         | `string`      | Partition to send message to
+`partitioner`       | `Partitioner` | `Partioner` object to be used (description bellow). Default for keyed messages will be [lib/lib/default-partitioner.js](lib/default-partitioner.js) which get a fixed partition number for key if partition number never changes, making [log compaction](https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction) easier to use.
+
+`Partitioner` (object):
+
+key                 | Type                                             | Description
+------------------- | ---------                                        | ---
+`partition`         | `function(key, numberOfPartitions)` -> `Number`  | Object function called before publishing message and should return an absolute `Number` that will be used as the partition number (so it should NOT be greater than the param `numberOfPartitions` received)
+
 
 - `key` (`function`): If provided, it is the function (`function(req, res, callback) {}`) that is called to generate a key for the message before being sent to kafka topic. `callback` expected to be called in the format `callback(error, key)`, where `key` is expected to be a `string`
 

--- a/example/index.js
+++ b/example/index.js
@@ -11,7 +11,7 @@ var kafka = {
     client_id: process.env.KAFKA_PRODUCER_ID || 'kafka-node-producer'
   },
   producer: {
-    topic: 'my-node-topic-test',
+    topic: 'my-node-topic',
     attributes: 1,
     // partition: 1,
     settings: { // https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38

--- a/example/index.js
+++ b/example/index.js
@@ -11,7 +11,7 @@ var kafka = {
     client_id: process.env.KAFKA_PRODUCER_ID || 'kafka-node-producer'
   },
   producer: {
-    topic: 'my-node-topic',
+    topic: 'my-node-topic-test',
     attributes: 1,
     // partition: 1,
     settings: { // https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38
@@ -61,7 +61,7 @@ app.get('/batch/:key', expressProducer(_.defaults({
   batch: {
     enabled: true,
     payload: 100,
-    timeout: 5000
+    timeout: 500
   }
 }, kafka)), function(req, res) {
   var msg = 'called after kafka publishing to topic \'' + kafka.producer.topic + '\' with key: ' + req.params.key;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var kafka = require('kafka-node'),
 
     Message = require('./lib//message')(_),
     Publish = require('./lib/publish')(_, async_timed_cargo, kafka);
+    DefaultPartitioner = require('./lib/default-partitioner')();
 
-var middleware = require('./lib/middleware')(kafka, Message, Publish, _);
+var middleware = require('./lib/middleware')(kafka, Message, Publish, DefaultPartitioner, _);
 
 module.exports = middleware;

--- a/lib/default-partitioner.js
+++ b/lib/default-partitioner.js
@@ -1,0 +1,37 @@
+// based on
+//  https://github.com/kafka-dev/kafka/blob/b1e2d544d4e81571bbfe59defa62d5f7a674c9e0/core/src/main/scala/kafka/producer/DefaultPartitioner.scala
+
+module.exports = function() {
+
+    var Partitioner = {
+        partition: function(key, numberOfPartitions) {
+        if (!numberOfPartitions) numberOfPartitions = 0;
+
+        if (key) {
+          return Math.abs(Partitioner.hashCode(key) % numberOfPartitions);
+        }
+        else {
+          return Math.floor(Math.random() * numberOfPartitions);
+        }
+      },
+      // http://stackoverflow.com/a/7616484/429521
+      // http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/#comment-38551
+      hashCode: function(str) {
+        var hash = 0,
+        strlen = str.length,
+        i,
+        c;
+        if (strlen === 0) {
+          return hash;
+        }
+        for (i = 0; i < strlen; i++) {
+          c = str.charCodeAt(i);
+          hash = ((hash << 5) - hash) + c;
+          hash = hash & hash; // Convert to 32bit integer
+        }
+        return hash;
+      }
+    }
+
+    return Partitioner;
+}

--- a/lib/default-partitioner.js
+++ b/lib/default-partitioner.js
@@ -5,7 +5,7 @@ module.exports = function() {
 
     var Partitioner = {
         partition: function(key, numberOfPartitions) {
-        if (!numberOfPartitions) numberOfPartitions = 0;
+        if (!numberOfPartitions) return 0;
 
         if (key) {
           return Math.abs(Partitioner.hashCode(key) % numberOfPartitions);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,4 +1,4 @@
-module.exports = function(kafka, Message, Publish, _) {
+module.exports = function(kafka, Message, Publish, DefaultPartitioner, _) {
 
   var Middleware = function(options) {
 
@@ -34,9 +34,9 @@ module.exports = function(kafka, Message, Publish, _) {
     if (use_options.error && !_.isFunction(use_options.error)) {
       use_options.error = null;
     }
-        // settings: https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38
+    // settings: https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38
     var producer  = new kafka.HighLevelProducer(client, use_options.producer.settings || {}),
-        publisher = Publish.generate(producer, _.defaults({verbose: use_options.verbose, parse_to_json: true, batch: use_options.batch}, use_options.producer));
+        publisher = Publish.generate(producer, _.defaults({verbose: use_options.verbose, parse_to_json: true, batch: use_options.batch, partitioner: DefaultPartitioner}, use_options.producer), (client.topicPartitions[use_options.producer.topic] || []).length);
 
     if (use_options.verbose) {
       producer.on('ready', function () {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -12,13 +12,12 @@ module.exports = function(kafka, Message, Publish, DefaultPartitioner, _) {
         client_id: 'kafka-node-producer'
       }
     }
-
     if (use_options.client instanceof kafka.Client) {
       client = use_options.client;
     }
     else {
       if (use_options.verbose) {
-        console.log('> KAFKA MIDDLEWARE - Will conncet to ' + use_options.client.url)
+        console.log('> KAFKA MIDDLEWARE - Will connect to ' + use_options.client.url)
       }
       client = new kafka.Client(use_options.client.url, use_options.client.client_id, {});
     }
@@ -36,14 +35,28 @@ module.exports = function(kafka, Message, Publish, DefaultPartitioner, _) {
     }
     // settings: https://github.com/SOHU-Co/kafka-node/blob/7101c4e1818987f4b6f8cf52c7fd5565c11768db/lib/highLevelProducer.js#L37-L38
     var producer  = new kafka.HighLevelProducer(client, use_options.producer.settings || {}),
+        publisher = _.noop;
+
+    client.on('ready', function () {
+
+      if (publisher != _.noop) {
+        return;
+      }
+
+      // needs to forcely request topic metadata in order to get the proper number of partitions
+      client.refreshMetadata([use_options.producer.topic], function() {
+
         publisher = Publish.generate(producer, _.defaults({verbose: use_options.verbose, parse_to_json: true, batch: use_options.batch, partitioner: DefaultPartitioner}, use_options.producer), (client.topicPartitions[use_options.producer.topic] || []).length);
-
-    if (use_options.verbose) {
-      producer.on('ready', function () {
-        console.log('> KAFKA MIDDLEWARE - Producer Ready');
       });
-    }
 
+      if (use_options.verbose) {
+        console.log('> KAFKA MIDDLEWARE - Client Ready');
+        producer.on('ready', function () {
+          console.log('> KAFKA MIDDLEWARE - Producer Ready');
+        });
+      }
+
+    });
     var middleware = function(req, res, next) {
 
       var sent = function(err, message) {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,9 @@ module.exports = function(_, async_timed_cargo, kafka) {
 
   var Publish = {
 
-    generate: function(producer, options) {
+    generate: function(producer, options, numberOfPartitions) {
+
+      if (!numberOfPartitions) numberOfPartitions = 0;
 
       var cargo_timeout = 500;
       var cargo_payload = 1;
@@ -12,20 +14,18 @@ module.exports = function(_, async_timed_cargo, kafka) {
       }
 
       var cargo = async_timed_cargo(function(tasks, callback) {
-        var payload = {
-          topic: options.topic,
-        };
+
+        var partition = 0;
+
         if (options.partition) {
-          payload.partition = options.partition;
-        }
-        if (options.attributes) {
-          payload.attributes = options.attributes;
+          partition = options.partition;
         }
 
-        messages = tasks.map(function(task) {
+        var messages = tasks.map(function(task) {
 
           var key = task.key,
-              message = task.message;
+              message = task.message,
+              message_partition = partition;
 
           if (options.parse_to_json != false && !_.isString(message)) {
             message = JSON.stringify(message)
@@ -37,20 +37,66 @@ module.exports = function(_, async_timed_cargo, kafka) {
               key = JSON.stringify(key)
             }
 
-            return new kafka.KeyedMessage(key, message);
-          } else {
-            return message;
-          }
+            if (options.partitioner) {
+              partition = options.partitioner.partition(key, numberOfPartitions);
+            }
+            else
 
+            return {
+              partition: message_partition,
+              message: new kafka.KeyedMessage(key, message)
+            }
+          }
+          else {
+            return {
+              partition: message_partition,
+              message: message
+            }
+          }
         });
 
-        if (!(options.batch && options.batch.enabled) && messages.length == 1) {
-          payload.messages = messages[0];
-        } else {
-          payload.messages = messages;
-        }
+        // transforming [{partition: 1, message: "aaa"}, {partition: 2, message: ["bbb"]}]
+        //  to {1: ["aaa"], 2: ["bbb"]}
+        messages = _.chain(messages)
+          .groupBy('partition') // returns {1: [{partition: 1, message: "aaa"}], 2: [{partition: 2, message: "bbb"}]}
+          .mapValues(function(value, key, object) {
+            return _.pluck(value, 'message')
+          }) // returns {1: "aaa", 2: ["bbb"]}
+          .value()
 
-        producer.send([payload], function (err, data) {
+        var partitions = Object.keys(messages);
+
+        var payloads = partitions.map(function(partition) {
+          var payload = {
+            topic: options.topic,
+          };
+
+          if (options.attributes) {
+            payload.attributes = options.attributes;
+          }
+
+          var partition_messages = messages[partition];
+
+          var isMessageIsArrayWithSingleElement = _.isArray(partition_messages) && partition_messages.length == 1;
+          var isUsingBatch = options.batch && options.batch.enabled;
+          var isParsingMessagesToString = options.parse_to_json != false && isMessageIsArrayWithSingleElement && !_.isString(partition_messages[0]);
+          var shouldUseOnlyFirstMessageInCollection = isMessageIsArrayWithSingleElement && (!isUsingBatch || isParsingMessagesToString);
+
+          if (shouldUseOnlyFirstMessageInCollection) {
+            payload.messages = partition_messages[0];
+          }
+          else {
+            payload.messages = partition_messages;
+          }
+
+          payload.partition = partition;
+          
+          return payload;
+        });
+
+
+
+        producer.send(payloads, function (err, data) {
           if (options.verbose) {
             if (err) {
               console.log("> KAFKA MIDDLEWARE PUBLISH - Error Sending Message: " + err);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,7 +3,6 @@ module.exports = function(_, async_timed_cargo, kafka) {
   var Publish = {
 
     generate: function(producer, options, numberOfPartitions) {
-
       if (!numberOfPartitions) numberOfPartitions = 0;
 
       var cargo_timeout = 500;
@@ -13,9 +12,12 @@ module.exports = function(_, async_timed_cargo, kafka) {
         cargo_payload = options.batch.payload || 1000;
       }
 
+      var isUsingPartitioner = _.isObject(options.partitioner) && _.isFunction(options.partitioner.partition);
+
       var cargo = async_timed_cargo(function(tasks, callback) {
 
         var partition = 0;
+        var no_partition = "NO PARTITION";
 
         if (options.partition) {
           partition = options.partition;
@@ -37,7 +39,7 @@ module.exports = function(_, async_timed_cargo, kafka) {
               key = JSON.stringify(key)
             }
 
-            if (_.isObject(options.partitioner) && _.isFunction(options.partitioner.partition)) {
+            if (isUsingPartitioner) {
               message_partition = options.partitioner.partition(key, numberOfPartitions);
             }
 
@@ -47,6 +49,11 @@ module.exports = function(_, async_timed_cargo, kafka) {
             }
           }
           else {
+
+            if (!options.partition) {
+              message_partition = no_partition;
+            }
+
             return {
               partition: message_partition,
               message: message
@@ -73,7 +80,6 @@ module.exports = function(_, async_timed_cargo, kafka) {
           if (options.attributes) {
             payload.attributes = options.attributes;
           }
-
           var partition_messages = messages[partition];
 
           var isMessageIsArrayWithSingleElement = _.isArray(partition_messages) && partition_messages.length == 1;
@@ -88,7 +94,9 @@ module.exports = function(_, async_timed_cargo, kafka) {
             payload.messages = partition_messages;
           }
 
-          payload.partition = partition;
+          if (partition != no_partition) {
+            payload.partition = partition;
+          }
 
           return payload;
         });

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -37,10 +37,9 @@ module.exports = function(_, async_timed_cargo, kafka) {
               key = JSON.stringify(key)
             }
 
-            if (options.partitioner) {
-              partition = options.partitioner.partition(key, numberOfPartitions);
+            if (_.isObject(options.partitioner) && _.isFunction(options.partitioner.partition)) {
+              message_partition = options.partitioner.partition(key, numberOfPartitions);
             }
-            else
 
             return {
               partition: message_partition,
@@ -90,11 +89,9 @@ module.exports = function(_, async_timed_cargo, kafka) {
           }
 
           payload.partition = partition;
-          
+
           return payload;
         });
-
-
 
         producer.send(payloads, function (err, data) {
           if (options.verbose) {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "dependencies": {
     "kafka-node": "0.2.24",
-    "lodash": "~2.2.1",
+    "lodash": "~2.4.1",
     "async-timed-cargo": "0.0.3"
   },
   "devDependencies": {
-    "chai": "1.10.0",
+    "chai": "3.0.0",
     "mocha": "1.21.5",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",

--- a/tests/default-partitioner-tests.js
+++ b/tests/default-partitioner-tests.js
@@ -1,0 +1,54 @@
+var chai    = require('chai'),
+    expect  = chai.expect,
+    assert  = chai.assert,
+    _       = require('lodash'),
+    DefaultPartitioner = require('../lib/default-partitioner')();
+
+describe('Default Partitioner', function() {
+
+  describe('no key provided', function() {
+    it('should create random key', function() {
+
+      var originalMathRandom = Math.random;
+      Math.random = function() {
+        return 0.1;
+      }
+      var part = DefaultPartitioner.partition(null, 10);
+      assert.equal(part, 1);
+
+      Math.random = originalMathRandom;
+
+    })
+  })
+
+  describe('key was provided', function() {
+
+    describe('Hash function', function() {
+      it('should return number for any given random string', function() {
+        assert.isNumber(DefaultPartitioner.hashCode('some key'));
+        assert.isNumber(DefaultPartitioner.hashCode('another key'));
+        assert.isNumber(DefaultPartitioner.hashCode('string:with_random|chars!'));
+        assert.isNumber(DefaultPartitioner.hashCode('12345'));
+      });
+    });
+
+
+    describe('key function', function() {
+
+      it('should use key to get partition', function() {
+
+        var key = "my:random:key";
+        var numberOfPartitions = 10;
+        var partition = DefaultPartitioner.partition(key, numberOfPartitions);
+
+        assert.isNumber(partition);
+        assert.isBelow(partition, numberOfPartitions);
+
+      });
+
+    });
+
+
+  })
+
+});

--- a/tests/default-partitioner-tests.js
+++ b/tests/default-partitioner-tests.js
@@ -46,6 +46,17 @@ describe('Default Partitioner', function() {
 
       });
 
+      it('should return0 if 0 partitions are available', function() {
+
+        var key = "my:random:key";
+        var numberOfPartitions = 0;
+        var partition = DefaultPartitioner.partition(key, numberOfPartitions);
+
+        assert.isNumber(partition);
+        assert.equal(partition, 0)
+
+      });
+
     });
 
 

--- a/tests/publish-tests.js
+++ b/tests/publish-tests.js
@@ -14,6 +14,7 @@ describe('Publish', function() {
     delete producer.send;
   });
 
+
   describe('single messages', function() {
 
     it('should create payload accordingly', function(done) {
@@ -46,6 +47,7 @@ describe('Publish', function() {
 
       producer.send = function(payloads, cb) {
         assert.lengthOf(payloads, 1, 'payloads`s value has a length of 1');
+        assert.equal(payloads[0].partition, 2);
         assert.isString(payloads[0].messages);
         done();
       };
@@ -111,6 +113,7 @@ describe('Publish', function() {
 
       producer.send = function(payloads, cb) {
         assert.lengthOf(payloads, 1, 'payloads`s value has a length of 1');
+        assert.isArray(payloads[0].messages);
         assert.lengthOf(payloads[0].messages, 2, 'payload message`s value has a length of 2');
         assert.equal(payloads[0].messages[0], 'test', 'message[0] is \'test\'');
         assert.equal(payloads[0].messages[1], 'test 2', 'message[1] is \'test 2\'');

--- a/tests/publish-tests.js
+++ b/tests/publish-tests.js
@@ -105,6 +105,28 @@ describe('Publish', function() {
       publisher({"message key": "message value"}, {'key key': 'key value'});
     });
 
+    it('should use partitioner if provided', function(done) {
+
+      var partition = 123;
+
+      producer.send = function(payloads, cb) {
+        assert.lengthOf(payloads, 1, 'payloads`s value has a length of 1');
+        assert.equal(payloads[0].partition, partition);
+        done();
+      };
+
+      var partitioner = {
+        partition:function(key, numberOfPartitions) {
+          assert.equal(key, 'xyz');
+          return partition;
+        }
+      }
+
+      var publisher = Publish.generate(producer, {topic: 'my-topic', partitioner: partitioner});
+
+      publisher('test', 'xyz');
+    });
+
   });
 
   describe('batching messages', function() {

--- a/tests/publish-tests.js
+++ b/tests/publish-tests.js
@@ -23,9 +23,24 @@ describe('Publish', function() {
         assert.lengthOf(payloads, 1, 'payloads`s value has a length of 1');
         assert.equal(payloads[0].messages, 'test', 'message is \'test\'');
         assert.equal(payloads[0].topic, 'my-topic', 'topic is \'my-topic\'');
+        assert.isUndefined(payloads[0].partition, 'partition should not be provided with no key')
         done();
       };
       var publisher = Publish.generate(producer, {topic: 'my-topic'});
+
+      publisher('test', null);
+    });
+
+    it('should create payload with  partition if default partition was provided and no key was provided with message', function(done) {
+
+      producer.send = function(payloads, cb) {
+        assert.lengthOf(payloads, 1, 'payloads`s value has a length of 1');
+        assert.equal(payloads[0].messages, 'test', 'message is \'test\'');
+        assert.equal(payloads[0].topic, 'my-topic', 'topic is \'my-topic\'');
+        assert.equal(payloads[0].partition, 1, 'partition should be equal one provided in options');
+        done();
+      };
+      var publisher = Publish.generate(producer, {topic: 'my-topic', partition: 1});
 
       publisher('test', null);
     });


### PR DESCRIPTION
Added partitioner based on [Kafka's Java producer default partitioner](https://github.com/kafka-dev/kafka/blob/b1e2d544d4e81571bbfe59defa62d5f7a674c9e0/core/src/main/scala/kafka/producer/DefaultPartitioner.scala)
- [x] Custom partitioner can be used
- [x] Partition is now being set per message, so payload creation logic was changed significantly
- [x] Updated tests
- [x] Update Examples
- [x] Test with Kafka cluster
- [x] Add partitioner usage to README/Docs
